### PR TITLE
Docker file for maven builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
-LABEL authors="Adam"
-
-ENTRYPOINT ["top", "-b"]
+FROM eclipse-temurin:17-jdk-alpine
+VOLUME /tmp
+COPY target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Local database must be accessible during maven build, in order to run the image locally make sure to link the container network with the host
```sh
docker run --network host ...
```